### PR TITLE
Fix height being unsynched due to async

### DIFF
--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -570,21 +570,22 @@ Bitcoin.prototype._updateTip = function(node, message) {
         self.height = response.result.height;
         $.checkState(self.height >= 0);
         self.emit('tip', self.height);
+        
+        if(!self.node.stopping) {
+          self.syncPercentage(function(err, percentage) {
+            if (err) {
+              self.emit('error', err);
+            } else {
+              if (Math.round(percentage) >= 100) {
+                self.emit('synced', self.height);
+              }
+              log.info('Bitcoin Height:', self.height, 'Percentage:', percentage.toFixed(2));
+            }
+          });
+        }
+        
       }
     });
-
-    if(!self.node.stopping) {
-      self.syncPercentage(function(err, percentage) {
-        if (err) {
-          self.emit('error', err);
-        } else {
-          if (Math.round(percentage) >= 100) {
-            self.emit('synced', self.height);
-          }
-          log.info('Bitcoin Height:', self.height, 'Percentage:', percentage.toFixed(2));
-        }
-      });
-    }
   }
 };
 


### PR DESCRIPTION
Because of your queue modification, the block height is becoming out of sync when the sync check occurs before the height definition is completed