### PR TITLE
fix binary link

### DIFF
--- a/scripts/download
+++ b/scripts/download
@@ -51,7 +51,7 @@ download_bitcoind() {
             echo "Unpacking bitcoin distribution"
             tar -xvzf $tarball_name
             if test $? -eq 0; then
-                ln -sf "bitcoin-${version}/bin/bitcoind"
+                ln -sf "bitcoin-abc-${version}/bin/bitcoind"
                 return;
             fi
         fi


### PR DESCRIPTION
The binary name has changed to include an "abc-" component. satoshilabs' fork of bitcore for Bitcoin ABC won't install without this fix. After fixing this it will be necessary to update the package.json in satoshilabs' Bitcoin ABC branch of bitcore.